### PR TITLE
fix(ahwr-1794): sns message sending erroring #patch

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -39,6 +39,8 @@ services:
     restart: always
 
   ahwr-application-backend:
+    image: ahwr-application-backend-development
+    container_name: ahwr-application-backend-development
     build:
       context: .
       target: development

--- a/package-lock.json
+++ b/package-lock.json
@@ -7961,9 +7961,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.0.tgz",
-      "integrity": "sha512-MTcrUoRQ1GSQ9iG3QJzBGquYYYeA7piZaJoIWbPFGbRn6Jj6z7xgoAyi4DrZX4y2ZIQQBF59gc/zmvvejjgoFQ==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.8.0.tgz",
+      "integrity": "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==",
       "funding": [
         {
           "type": "github",
@@ -7973,9 +7973,10 @@
       "license": "MIT",
       "dependencies": {
         "@nodable/entities": "^2.1.0",
-        "fast-xml-builder": "^1.1.5",
+        "fast-xml-builder": "^1.2.0",
         "path-expression-matcher": "^1.5.0",
-        "strnum": "^2.2.3"
+        "strnum": "^2.3.0",
+        "xml-naming": "^0.1.0"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -15113,9 +15114,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
-      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     },
     "semver": "7.5.2",
     "brace-expansion": "2.0.2",
-    "fast-xml-parser": "5.7.0"
+    "fast-xml-parser": "5.8.0"
   },
   "devDependencies": {
     "@babel/core": "7.27.4",

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -369,7 +369,7 @@ const config = convict({
   },
   distributedJobs: {
     v0820SupportingData: {
-      doc: 'Data to support v0.82.0 data changes',
+      doc: 'Data to support v0.82.1 data changes',
       format: Object,
       default: {},
       sensitive: true,

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -368,7 +368,7 @@ const config = convict({
     }
   },
   distributedJobs: {
-    v0820SupportingData: {
+    v0821SupportingData: {
       doc: 'Data to support v0.82.1 data changes',
       format: Object,
       default: {},

--- a/src/distributed-jobs/distributed-startup-job.js
+++ b/src/distributed-jobs/distributed-startup-job.js
@@ -67,7 +67,7 @@ const hasStartupJobAlreadyRun = async (serviceVersion, environmentsJobWillRun, d
 }
 
 const performDataChanges = async (serviceVersion, supportingData, db, logger) => {
-  if (serviceVersion === '0.82.0') {
+  if (serviceVersion === '0.82.1') {
     await v0820DatastoreUpdates(serviceVersion, supportingData, db, logger)
     await v0820SendEvents(serviceVersion, supportingData, db, logger)
   } else {

--- a/src/distributed-jobs/distributed-startup-job.test.js
+++ b/src/distributed-jobs/distributed-startup-job.test.js
@@ -40,14 +40,14 @@ describe('Test runDistributedStartupJob', () => {
     config.get.mockImplementation((key) => {
       const values = {
         cdpEnvironment: 'local',
-        serviceVersion: '0.82.0',
+        serviceVersion: '0.82.1',
         'distributedJobs.v0820SupportingData': {}
       }
       return values[key]
     })
 
     await expect(runDistributedStartupJob(mockDB, mockLogger)).rejects.toThrow(
-      'Missing supporting data for service version 0.82.0'
+      'Missing supporting data for service version 0.82.1'
     )
   })
 
@@ -56,7 +56,7 @@ describe('Test runDistributedStartupJob', () => {
     config.get.mockImplementation((key) => {
       const values = {
         cdpEnvironment: 'local',
-        serviceVersion: '0.82.0',
+        serviceVersion: '0.82.1',
         'distributedJobs.v0820SupportingData': {
           mandatory: 'need-at-least-one-key-to-be-valid-data'
         }
@@ -77,7 +77,7 @@ describe('Test runDistributedStartupJob', () => {
     config.get.mockImplementation((key) => {
       const values = {
         cdpEnvironment: 'local',
-        serviceVersion: '0.82.0'
+        serviceVersion: '0.82.1'
       }
       return values[key]
     })
@@ -109,7 +109,7 @@ describe('Test runDistributedStartupJob', () => {
 
   // This test should change from data change to data change, don't forget to mock vXXXX-data-changes.js
   it('should run job and executes data changes', async () => {
-    const serviceVersion = '0.82.0'
+    const serviceVersion = '0.82.1'
     const supportingDataVersion = `v${serviceVersion.replaceAll('.', '')}SupportingData`
     const supportingDataConfigKey = `distributedJobs.${supportingDataVersion}`
 

--- a/src/distributed-jobs/distributed-startup-job.test.js
+++ b/src/distributed-jobs/distributed-startup-job.test.js
@@ -36,12 +36,12 @@ describe('Test runDistributedStartupJob', () => {
   })
 
   it('should not run job when supporting data is default/empty', async () => {
-    config.getProperties.mockReturnValue({ distributedJobs: { v0820SupportingData: {} } })
+    config.getProperties.mockReturnValue({ distributedJobs: { v0821SupportingData: {} } })
     config.get.mockImplementation((key) => {
       const values = {
         cdpEnvironment: 'local',
         serviceVersion: '0.82.1',
-        'distributedJobs.v0820SupportingData': {}
+        'distributedJobs.v0821SupportingData': {}
       }
       return values[key]
     })
@@ -52,12 +52,12 @@ describe('Test runDistributedStartupJob', () => {
   })
 
   it('should not run job when already been run', async () => {
-    config.getProperties.mockReturnValue({ distributedJobs: { v0820SupportingData: {} } })
+    config.getProperties.mockReturnValue({ distributedJobs: { v0821SupportingData: {} } })
     config.get.mockImplementation((key) => {
       const values = {
         cdpEnvironment: 'local',
         serviceVersion: '0.82.1',
-        'distributedJobs.v0820SupportingData': {
+        'distributedJobs.v0821SupportingData': {
           mandatory: 'need-at-least-one-key-to-be-valid-data'
         }
       }


### PR DESCRIPTION
There is a bug on fast-xml-parser 5.7.0 (https://github.com/NaturalIntelligence/fast-xml-parser/issues/823)

This seems to affect the ui-tests as trying to send messages to sns gets the application to fail.

Changed the image and container names on compose.yml, so it can fit better with the paradigm on the other services and be usable with the new --local parameter in ui-tests.

And corrected version numbers for the data changes, so when we deploy we still process them.