### PR TITLE
fix(AHWR-1850): scope /claims/count by claim species #patch

### DIFF
--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -95,8 +95,3 @@ export const APPLICATION_COLLECTION = 'applications'
 export const OW_APPLICATION_COLLECTION = 'owapplications'
 export const CLAIMS_COLLECTION = 'claims'
 export const HERDS_COLLECTION = 'herds'
-
-export const SPECIES = {
-  POULTRY: 'poultry',
-  LIVESTOCK: 'livestock'
-}

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -95,3 +95,8 @@ export const APPLICATION_COLLECTION = 'applications'
 export const OW_APPLICATION_COLLECTION = 'owapplications'
 export const CLAIMS_COLLECTION = 'claims'
 export const HERDS_COLLECTION = 'herds'
+
+export const SPECIES = {
+  POULTRY: 'poultry',
+  LIVESTOCK: 'livestock'
+}

--- a/src/repositories/claim-repository.js
+++ b/src/repositories/claim-repository.js
@@ -1,10 +1,10 @@
-import { STATUS } from 'ffc-ahwr-common-library'
-import { CLAIMS_COLLECTION, SPECIES } from '../constants/index.js'
+import { STATUS, POULTRY_SCHEME, AHWR_SCHEME } from 'ffc-ahwr-common-library'
+import { CLAIMS_COLLECTION } from '../constants/index.js'
 import crypto from 'node:crypto'
 
-const SPECIES_FILTER = {
-  [SPECIES.POULTRY]: { 'data.typesOfPoultry': { $exists: true } },
-  [SPECIES.LIVESTOCK]: { 'data.typeOfLivestock': { $exists: true } }
+const SCHEME_FILTER = {
+  [POULTRY_SCHEME]: { 'data.typesOfPoultry': { $exists: true } },
+  [AHWR_SCHEME]: { 'data.typeOfLivestock': { $exists: true } }
 }
 
 export const createClaimIndexes = async (db) => {
@@ -106,11 +106,11 @@ export const isURNUnique = async ({ db, applicationReferences, laboratoryURN }) 
   return !result
 }
 
-export const getClaimsCount = async ({ db, cph, herdId, species }) => {
+export const getClaimsCount = async ({ db, cph, herdId, scheme }) => {
   const query = {
     'herd.cph': cph,
     'herd.id': { $ne: herdId },
-    ...SPECIES_FILTER[species]
+    ...SCHEME_FILTER[scheme]
   }
 
   return db.collection(CLAIMS_COLLECTION).countDocuments(query)

--- a/src/repositories/claim-repository.js
+++ b/src/repositories/claim-repository.js
@@ -1,5 +1,5 @@
 import { STATUS } from 'ffc-ahwr-common-library'
-import { CLAIMS_COLLECTION } from '../constants/index.js'
+import { CLAIMS_COLLECTION, SPECIES } from '../constants/index.js'
 import crypto from 'node:crypto'
 
 export const createClaimIndexes = async (db) => {
@@ -101,11 +101,19 @@ export const isURNUnique = async ({ db, applicationReferences, laboratoryURN }) 
   return !result
 }
 
-export const getClaimsCount = async ({ db, cph, herdId }) => {
-  return db.collection(CLAIMS_COLLECTION).countDocuments({
+export const getClaimsCount = async ({ db, cph, herdId, species }) => {
+  const query = {
     'herd.cph': cph,
     'herd.id': { $ne: herdId }
-  })
+  }
+
+  if (species === SPECIES.POULTRY) {
+    query['data.typesOfPoultry'] = { $exists: true }
+  } else if (species === SPECIES.LIVESTOCK) {
+    query['data.typeOfLivestock'] = { $exists: true }
+  }
+
+  return db.collection(CLAIMS_COLLECTION).countDocuments(query)
 }
 
 export const updateClaimData = async ({

--- a/src/repositories/claim-repository.js
+++ b/src/repositories/claim-repository.js
@@ -2,6 +2,11 @@ import { STATUS } from 'ffc-ahwr-common-library'
 import { CLAIMS_COLLECTION, SPECIES } from '../constants/index.js'
 import crypto from 'node:crypto'
 
+const SPECIES_FILTER = {
+  [SPECIES.POULTRY]: { 'data.typesOfPoultry': { $exists: true } },
+  [SPECIES.LIVESTOCK]: { 'data.typeOfLivestock': { $exists: true } }
+}
+
 export const createClaimIndexes = async (db) => {
   await db.collection(CLAIMS_COLLECTION).createIndex({
     createdAt: -1,
@@ -104,13 +109,8 @@ export const isURNUnique = async ({ db, applicationReferences, laboratoryURN }) 
 export const getClaimsCount = async ({ db, cph, herdId, species }) => {
   const query = {
     'herd.cph': cph,
-    'herd.id': { $ne: herdId }
-  }
-
-  if (species === SPECIES.POULTRY) {
-    query['data.typesOfPoultry'] = { $exists: true }
-  } else if (species === SPECIES.LIVESTOCK) {
-    query['data.typeOfLivestock'] = { $exists: true }
+    'herd.id': { $ne: herdId },
+    ...SPECIES_FILTER[species]
   }
 
   return db.collection(CLAIMS_COLLECTION).countDocuments(query)

--- a/src/repositories/claim-repository.test.js
+++ b/src/repositories/claim-repository.test.js
@@ -641,6 +641,46 @@ describe('claim-repository', () => {
       expect(result).toEqual(2)
     })
 
+    describe('with species filter', () => {
+      it('scopes the count to Poultry claims when species is "poultry"', async () => {
+        mockCountDocuments.mockResolvedValue(1)
+
+        const result = await getClaimsCount({ db: mockDb, cph, herdId, species: 'poultry' })
+
+        expect(mockCountDocuments).toHaveBeenCalledWith({
+          'herd.cph': cph,
+          'herd.id': { $ne: herdId },
+          'data.typesOfPoultry': { $exists: true }
+        })
+        expect(result).toEqual(1)
+      })
+
+      it('scopes the count to Livestock claims when species is "livestock"', async () => {
+        mockCountDocuments.mockResolvedValue(3)
+
+        const result = await getClaimsCount({ db: mockDb, cph, herdId, species: 'livestock' })
+
+        expect(mockCountDocuments).toHaveBeenCalledWith({
+          'herd.cph': cph,
+          'herd.id': { $ne: herdId },
+          'data.typeOfLivestock': { $exists: true }
+        })
+        expect(result).toEqual(3)
+      })
+
+      it('applies the species filter even when herdId is not supplied', async () => {
+        mockCountDocuments.mockResolvedValue(2)
+
+        await getClaimsCount({ db: mockDb, cph, herdId: undefined, species: 'poultry' })
+
+        expect(mockCountDocuments).toHaveBeenCalledWith({
+          'herd.cph': cph,
+          'herd.id': { $ne: undefined },
+          'data.typesOfPoultry': { $exists: true }
+        })
+      })
+    })
+
     it('propagates errors from the database', async () => {
       const error = new Error('DB failure')
       mockCountDocuments.mockRejectedValue(error)

--- a/src/repositories/claim-repository.test.js
+++ b/src/repositories/claim-repository.test.js
@@ -13,7 +13,7 @@ import {
   updateHerd
 } from './claim-repository.js'
 import { CLAIMS_COLLECTION } from '../constants/index.js'
-import { STATUS } from 'ffc-ahwr-common-library'
+import { STATUS, POULTRY_SCHEME, AHWR_SCHEME } from 'ffc-ahwr-common-library'
 
 describe('claim-repository', () => {
   describe('getByApplicationReference', () => {
@@ -641,11 +641,11 @@ describe('claim-repository', () => {
       expect(result).toEqual(2)
     })
 
-    describe('with species filter', () => {
-      it('scopes the count to Poultry claims when species is "poultry"', async () => {
+    describe('with scheme filter', () => {
+      it('scopes the count to Poultry claims for the poultry scheme', async () => {
         mockCountDocuments.mockResolvedValue(1)
 
-        const result = await getClaimsCount({ db: mockDb, cph, herdId, species: 'poultry' })
+        const result = await getClaimsCount({ db: mockDb, cph, herdId, scheme: POULTRY_SCHEME })
 
         expect(mockCountDocuments).toHaveBeenCalledWith({
           'herd.cph': cph,
@@ -655,10 +655,10 @@ describe('claim-repository', () => {
         expect(result).toEqual(1)
       })
 
-      it('scopes the count to Livestock claims when species is "livestock"', async () => {
+      it('scopes the count to Livestock claims for the ahwr scheme', async () => {
         mockCountDocuments.mockResolvedValue(3)
 
-        const result = await getClaimsCount({ db: mockDb, cph, herdId, species: 'livestock' })
+        const result = await getClaimsCount({ db: mockDb, cph, herdId, scheme: AHWR_SCHEME })
 
         expect(mockCountDocuments).toHaveBeenCalledWith({
           'herd.cph': cph,
@@ -668,10 +668,10 @@ describe('claim-repository', () => {
         expect(result).toEqual(3)
       })
 
-      it('applies the species filter even when herdId is not supplied', async () => {
+      it('applies the scheme filter even when herdId is not supplied', async () => {
         mockCountDocuments.mockResolvedValue(2)
 
-        await getClaimsCount({ db: mockDb, cph, herdId: undefined, species: 'poultry' })
+        await getClaimsCount({ db: mockDb, cph, herdId: undefined, scheme: POULTRY_SCHEME })
 
         expect(mockCountDocuments).toHaveBeenCalledWith({
           'herd.cph': cph,

--- a/src/routes/api/claims/claims-controller.js
+++ b/src/routes/api/claims/claims-controller.js
@@ -67,12 +67,13 @@ export const isURNUniqueHandler = async (request, h) => {
 
 export const getClaimsCountHandler = async (request, h) => {
   try {
-    const { cph, herdId } = request.query
+    const { cph, herdId, species } = request.query
 
     const count = await getClaimsCount({
       db: request.db,
       cph,
-      herdId
+      herdId,
+      species
     })
 
     const response = {

--- a/src/routes/api/claims/claims-controller.js
+++ b/src/routes/api/claims/claims-controller.js
@@ -67,13 +67,13 @@ export const isURNUniqueHandler = async (request, h) => {
 
 export const getClaimsCountHandler = async (request, h) => {
   try {
-    const { cph, herdId, species } = request.query
+    const { cph, herdId, scheme } = request.query
 
     const count = await getClaimsCount({
       db: request.db,
       cph,
       herdId,
-      species
+      scheme
     })
 
     const response = {

--- a/src/routes/api/claims/claims-controller.test.js
+++ b/src/routes/api/claims/claims-controller.test.js
@@ -18,7 +18,7 @@ import {
 import { ObjectId } from 'mongodb'
 import { findApplication, getApplication } from '../../../repositories/application-repository.js'
 import { raiseClaimEvents } from '../../../event-publisher/index.js'
-import { STATUS } from 'ffc-ahwr-common-library'
+import { STATUS, POULTRY_SCHEME, AHWR_SCHEME } from 'ffc-ahwr-common-library'
 import {
   publishRequestForPaymentEvent,
   publishStatusChangeEvent
@@ -237,45 +237,45 @@ describe('getClaimsCountHandler', () => {
     expect(result).toBe(mockH)
   })
 
-  it('should pass species through to getClaimsCount when species is "poultry"', async () => {
-    const requestWithSpecies = {
+  it('should pass scheme through to getClaimsCount for the poultry scheme', async () => {
+    const requestWithScheme = {
       ...mockRequest,
       query: {
         cph: '22/333/4444',
         herdId: '0e4f55ea-ed42-4139-9c46-c75ba63b0742',
-        species: 'poultry'
+        scheme: POULTRY_SCHEME
       }
     }
     getClaimsCount.mockResolvedValue(1)
 
-    await getClaimsCountHandler(requestWithSpecies, mockH)
+    await getClaimsCountHandler(requestWithScheme, mockH)
 
     expect(getClaimsCount).toHaveBeenCalledWith({
       cph: '22/333/4444',
       herdId: '0e4f55ea-ed42-4139-9c46-c75ba63b0742',
-      species: 'poultry',
-      db: requestWithSpecies.db
+      scheme: POULTRY_SCHEME,
+      db: requestWithScheme.db
     })
   })
 
-  it('should pass species through to getClaimsCount when species is "livestock"', async () => {
-    const requestWithSpecies = {
+  it('should pass scheme through to getClaimsCount for the ahwr scheme', async () => {
+    const requestWithScheme = {
       ...mockRequest,
       query: {
         cph: '22/333/4444',
         herdId: '0e4f55ea-ed42-4139-9c46-c75ba63b0742',
-        species: 'livestock'
+        scheme: AHWR_SCHEME
       }
     }
     getClaimsCount.mockResolvedValue(3)
 
-    await getClaimsCountHandler(requestWithSpecies, mockH)
+    await getClaimsCountHandler(requestWithScheme, mockH)
 
     expect(getClaimsCount).toHaveBeenCalledWith({
       cph: '22/333/4444',
       herdId: '0e4f55ea-ed42-4139-9c46-c75ba63b0742',
-      species: 'livestock',
-      db: requestWithSpecies.db
+      scheme: AHWR_SCHEME,
+      db: requestWithScheme.db
     })
   })
 

--- a/src/routes/api/claims/claims-controller.test.js
+++ b/src/routes/api/claims/claims-controller.test.js
@@ -237,6 +237,48 @@ describe('getClaimsCountHandler', () => {
     expect(result).toBe(mockH)
   })
 
+  it('should pass species through to getClaimsCount when species is "poultry"', async () => {
+    const requestWithSpecies = {
+      ...mockRequest,
+      query: {
+        cph: '22/333/4444',
+        herdId: '0e4f55ea-ed42-4139-9c46-c75ba63b0742',
+        species: 'poultry'
+      }
+    }
+    getClaimsCount.mockResolvedValue(1)
+
+    await getClaimsCountHandler(requestWithSpecies, mockH)
+
+    expect(getClaimsCount).toHaveBeenCalledWith({
+      cph: '22/333/4444',
+      herdId: '0e4f55ea-ed42-4139-9c46-c75ba63b0742',
+      species: 'poultry',
+      db: requestWithSpecies.db
+    })
+  })
+
+  it('should pass species through to getClaimsCount when species is "livestock"', async () => {
+    const requestWithSpecies = {
+      ...mockRequest,
+      query: {
+        cph: '22/333/4444',
+        herdId: '0e4f55ea-ed42-4139-9c46-c75ba63b0742',
+        species: 'livestock'
+      }
+    }
+    getClaimsCount.mockResolvedValue(3)
+
+    await getClaimsCountHandler(requestWithSpecies, mockH)
+
+    expect(getClaimsCount).toHaveBeenCalledWith({
+      cph: '22/333/4444',
+      herdId: '0e4f55ea-ed42-4139-9c46-c75ba63b0742',
+      species: 'livestock',
+      db: requestWithSpecies.db
+    })
+  })
+
   it('should rethrow Boom errors', async () => {
     const boomError = Boom.badRequest('Invalid input')
     getClaimsCount.mockRejectedValue(boomError)

--- a/src/routes/api/claims/claims-routes.js
+++ b/src/routes/api/claims/claims-routes.js
@@ -2,6 +2,7 @@ import joi from 'joi'
 import { searchPayloadSchema } from '../schema/search-payload.schema.js'
 import { StatusCodes } from 'http-status-codes'
 import { searchClaims } from '../../../repositories/claim/claim-search-repository.js'
+import { SPECIES } from '../../../constants/index.js'
 import {
   createClaimHandler,
   isURNUniqueHandler,
@@ -82,7 +83,8 @@ export const claimsHandlers = [
       validate: {
         query: joi.object({
           cph: joi.string().optional(),
-          herdId: joi.string().optional()
+          herdId: joi.string().optional(),
+          species: joi.string().valid(SPECIES.POULTRY, SPECIES.LIVESTOCK).optional()
         })
       },
       handler: getClaimsCountHandler

--- a/src/routes/api/claims/claims-routes.js
+++ b/src/routes/api/claims/claims-routes.js
@@ -2,7 +2,7 @@ import joi from 'joi'
 import { searchPayloadSchema } from '../schema/search-payload.schema.js'
 import { StatusCodes } from 'http-status-codes'
 import { searchClaims } from '../../../repositories/claim/claim-search-repository.js'
-import { SPECIES } from '../../../constants/index.js'
+import { POULTRY_SCHEME, AHWR_SCHEME } from 'ffc-ahwr-common-library'
 import {
   createClaimHandler,
   isURNUniqueHandler,
@@ -84,7 +84,7 @@ export const claimsHandlers = [
         query: joi.object({
           cph: joi.string().optional(),
           herdId: joi.string().optional(),
-          species: joi.string().valid(SPECIES.POULTRY, SPECIES.LIVESTOCK).optional()
+          scheme: joi.string().valid(POULTRY_SCHEME, AHWR_SCHEME).optional()
         })
       },
       handler: getClaimsCountHandler

--- a/src/routes/api/claims/claims-routes.test.js
+++ b/src/routes/api/claims/claims-routes.test.js
@@ -135,6 +135,77 @@ describe('claims-routes', () => {
       expect(getClaimsCountHandler).toHaveBeenCalledTimes(1)
     })
 
+    it('should accept species=poultry and pass it through to the handler', async () => {
+      getClaimsCountHandler.mockImplementation(async (_, h) => {
+        return h.response({ count: 1 }).code(200)
+      })
+
+      const res = await server.inject({
+        method: 'GET',
+        url: '/api/claims/count?cph=123456789&herdId=0e4f55ea-ed42-4139-9c46-c75ba63b0742&species=poultry'
+      })
+
+      expect(res.statusCode).toBe(200)
+      expect(res.result).toEqual({ count: 1 })
+      expect(getClaimsCountHandler).toHaveBeenCalledTimes(1)
+      expect(getClaimsCountHandler.mock.calls[0][0].query).toEqual({
+        cph: '123456789',
+        herdId: '0e4f55ea-ed42-4139-9c46-c75ba63b0742',
+        species: 'poultry'
+      })
+    })
+
+    it('should accept species=livestock and pass it through to the handler', async () => {
+      getClaimsCountHandler.mockImplementation(async (_, h) => {
+        return h.response({ count: 3 }).code(200)
+      })
+
+      const res = await server.inject({
+        method: 'GET',
+        url: '/api/claims/count?cph=123456789&herdId=0e4f55ea-ed42-4139-9c46-c75ba63b0742&species=livestock'
+      })
+
+      expect(res.statusCode).toBe(200)
+      expect(getClaimsCountHandler).toHaveBeenCalledTimes(1)
+      expect(getClaimsCountHandler.mock.calls[0][0].query).toEqual({
+        cph: '123456789',
+        herdId: '0e4f55ea-ed42-4139-9c46-c75ba63b0742',
+        species: 'livestock'
+      })
+    })
+
+    it('should reject an invalid species value with 400 and not call the handler', async () => {
+      getClaimsCountHandler.mockImplementation(async (_, h) => {
+        return h.response({ count: 0 }).code(200)
+      })
+
+      const res = await server.inject({
+        method: 'GET',
+        url: '/api/claims/count?cph=123456789&herdId=0e4f55ea-ed42-4139-9c46-c75ba63b0742&species=alpacas'
+      })
+
+      expect(res.statusCode).toBe(400)
+      expect(getClaimsCountHandler).not.toHaveBeenCalled()
+    })
+
+    it('should still accept requests without species (legacy behaviour)', async () => {
+      getClaimsCountHandler.mockImplementation(async (_, h) => {
+        return h.response({ count: 2 }).code(200)
+      })
+
+      const res = await server.inject({
+        method: 'GET',
+        url: '/api/claims/count?cph=123456789&herdId=0e4f55ea-ed42-4139-9c46-c75ba63b0742'
+      })
+
+      expect(res.statusCode).toBe(200)
+      expect(getClaimsCountHandler).toHaveBeenCalledTimes(1)
+      expect(getClaimsCountHandler.mock.calls[0][0].query).toEqual({
+        cph: '123456789',
+        herdId: '0e4f55ea-ed42-4139-9c46-c75ba63b0742'
+      })
+    })
+
     it('should handle errors from handler', async () => {
       getClaimsCountHandler.mockImplementation(async () => {
         throw new Error('Database error')

--- a/src/routes/api/claims/claims-routes.test.js
+++ b/src/routes/api/claims/claims-routes.test.js
@@ -1,4 +1,5 @@
 import { Server } from '@hapi/hapi'
+import { POULTRY_SCHEME, AHWR_SCHEME } from 'ffc-ahwr-common-library'
 import { claimsHandlers } from './claims-routes.js'
 import {
   createClaimHandler,
@@ -135,14 +136,14 @@ describe('claims-routes', () => {
       expect(getClaimsCountHandler).toHaveBeenCalledTimes(1)
     })
 
-    it('should accept species=poultry and pass it through to the handler', async () => {
+    it('should accept the poultry scheme and pass it through to the handler', async () => {
       getClaimsCountHandler.mockImplementation(async (_, h) => {
         return h.response({ count: 1 }).code(200)
       })
 
       const res = await server.inject({
         method: 'GET',
-        url: '/api/claims/count?cph=123456789&herdId=0e4f55ea-ed42-4139-9c46-c75ba63b0742&species=poultry'
+        url: `/api/claims/count?cph=123456789&herdId=0e4f55ea-ed42-4139-9c46-c75ba63b0742&scheme=${POULTRY_SCHEME}`
       })
 
       expect(res.statusCode).toBe(200)
@@ -151,18 +152,18 @@ describe('claims-routes', () => {
       expect(getClaimsCountHandler.mock.calls[0][0].query).toEqual({
         cph: '123456789',
         herdId: '0e4f55ea-ed42-4139-9c46-c75ba63b0742',
-        species: 'poultry'
+        scheme: POULTRY_SCHEME
       })
     })
 
-    it('should accept species=livestock and pass it through to the handler', async () => {
+    it('should accept the ahwr scheme and pass it through to the handler', async () => {
       getClaimsCountHandler.mockImplementation(async (_, h) => {
         return h.response({ count: 3 }).code(200)
       })
 
       const res = await server.inject({
         method: 'GET',
-        url: '/api/claims/count?cph=123456789&herdId=0e4f55ea-ed42-4139-9c46-c75ba63b0742&species=livestock'
+        url: `/api/claims/count?cph=123456789&herdId=0e4f55ea-ed42-4139-9c46-c75ba63b0742&scheme=${AHWR_SCHEME}`
       })
 
       expect(res.statusCode).toBe(200)
@@ -170,25 +171,25 @@ describe('claims-routes', () => {
       expect(getClaimsCountHandler.mock.calls[0][0].query).toEqual({
         cph: '123456789',
         herdId: '0e4f55ea-ed42-4139-9c46-c75ba63b0742',
-        species: 'livestock'
+        scheme: AHWR_SCHEME
       })
     })
 
-    it('should reject an invalid species value with 400 and not call the handler', async () => {
+    it('should reject an invalid scheme value with 400 and not call the handler', async () => {
       getClaimsCountHandler.mockImplementation(async (_, h) => {
         return h.response({ count: 0 }).code(200)
       })
 
       const res = await server.inject({
         method: 'GET',
-        url: '/api/claims/count?cph=123456789&herdId=0e4f55ea-ed42-4139-9c46-c75ba63b0742&species=alpacas'
+        url: '/api/claims/count?cph=123456789&herdId=0e4f55ea-ed42-4139-9c46-c75ba63b0742&scheme=alpacas'
       })
 
       expect(res.statusCode).toBe(400)
       expect(getClaimsCountHandler).not.toHaveBeenCalled()
     })
 
-    it('should still accept requests without species (legacy behaviour)', async () => {
+    it('should still accept requests without a scheme (legacy behaviour)', async () => {
       getClaimsCountHandler.mockImplementation(async (_, h) => {
         return h.response({ count: 2 }).code(200)
       })


### PR DESCRIPTION
## Summary
Adds an optional `scheme` query parameter to `GET /api/claims/count` so callers can scope the claim-count check to one scheme (poultry or livestock). The endpoint remains backward compatible: when `scheme` is omitted, behaviour is unchanged.

## What Changed
- New optional `scheme` query parameter on `GET /api/claims/count`, accepting the poultry or ahwr scheme values from the common library
- Invalid values rejected with `400 Bad Request` via Joi validation
- Reuses the existing `POULTRY_SCHEME` / `AHWR_SCHEME` constants from the common library rather than introducing a new flavour enum
- Unit tests for the repository layer covering both schemes and the no-scheme legacy path
- Route-level tests asserting the new parameter is accepted, passed to the handler, and validated correctly

## Why
The Poultry "Enter CPH" screen currently rejects CPHs that have been used in an existing Livestock claim, because the underlying `/claims/count` call counts matches across all schemes. This change is the backend half of the fix: it gives the public UI a way to scope the count to poultry claims only, without breaking any existing caller. The follow-up public-ui change will pass the poultry scheme and align the on-screen error copy.