### PR TITLE
feat: ahwr-1874 changes and generalization code #patch

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -368,12 +368,12 @@ const config = convict({
     }
   },
   distributedJobs: {
-    v0826SupportingData: {
-      doc: 'Data to support v0.82.6 data changes',
+    v0827SupportingData: {
+      doc: 'Data to support v0.82.7 data changes',
       format: Object,
       default: {},
       sensitive: true,
-      env: 'DATA_CHANGE_V0826_DATA'
+      env: 'DATA_CHANGE_V0827_DATA'
     }
   }
 })

--- a/src/distributed-jobs/data-changes/process_changes.js
+++ b/src/distributed-jobs/data-changes/process_changes.js
@@ -10,7 +10,8 @@ import { changeSchema, TYPE_OF_CHANGE } from './schema.js'
  * @property {string} applicationRef - The application reference
  * @property {'deletion' | 'fieldChange'} action - The type of change to process
  * @property {string} [field] - Field name (required for fieldChange)
- * @property {string} [note] - A note with the reason for the change (required for fieldChange)
+ * @property {string} [dateRequested] - The day when the request was done in ISO 8601
+ * @property {string} [requester] - Who has made the request
  * @property {string | string[]} [newValue] - New value (required for fieldChange)
  * @property {string | string[]} [oldValue] - Old value (required for fieldChange)
  * @property {boolean} [skipDataChange] - Skip data change processing
@@ -105,7 +106,7 @@ const processDataChange = async (change, db) => {
       updatedProperty: change.field,
       newValue: change.newValue,
       oldValue: change.oldValue,
-      note: change.note,
+      note: `Requested on ${change.dateRequested} by ${change.requester}`,
       user: raisedBy,
       updatedAt: new Date()
     })
@@ -121,7 +122,7 @@ const processDataChange = async (change, db) => {
         newValue: change.newValue,
         oldValue: change.oldValue,
         updatedProperty: 'dateOfTesting',
-        note: change.note
+        note: `Requested on ${change.dateRequested} by ${change.requester}`
       },
       'claim-testResults',
       raisedBy,

--- a/src/distributed-jobs/data-changes/process_changes.js
+++ b/src/distributed-jobs/data-changes/process_changes.js
@@ -121,10 +121,10 @@ const processDataChange = async (change, db) => {
         reference: change.claimRef,
         newValue: change.newValue,
         oldValue: change.oldValue,
-        updatedProperty: 'dateOfTesting',
+        updatedProperty: change.field,
         note: `Requested on ${change.dateRequested} by ${change.requester}`
       },
-      'claim-testResults',
+      `claim-${change.field}`,
       raisedBy,
       new Date(),
       change.sbi

--- a/src/distributed-jobs/data-changes/process_changes.js
+++ b/src/distributed-jobs/data-changes/process_changes.js
@@ -1,5 +1,6 @@
+import { claimDataUpdateEvent } from '../../event-publisher/claim-data-update-event.js'
 import { raiseClaimEvents } from '../../event-publisher/index.js'
-import { deleteClaim } from '../../repositories/claim-repository.js'
+import { deleteClaim, updateClaimData } from '../../repositories/claim-repository.js'
 import { changeSchema, TYPE_OF_CHANGE } from './schema.js'
 
 /**
@@ -9,6 +10,7 @@ import { changeSchema, TYPE_OF_CHANGE } from './schema.js'
  * @property {string} applicationRef - The application reference
  * @property {'deletion' | 'fieldChange'} action - The type of change to process
  * @property {string} [field] - Field name (required for fieldChange)
+ * @property {string} [note] - A note with the reason for the change (required for fieldChange)
  * @property {string | string[]} [newValue] - New value (required for fieldChange)
  * @property {string | string[]} [oldValue] - Old value (required for fieldChange)
  * @property {boolean} [skipDataChange] - Skip data change processing
@@ -24,7 +26,7 @@ import { changeSchema, TYPE_OF_CHANGE } from './schema.js'
 /**
  * Processes a batch of claim changes (deletions or field updates).
  * Validates each change against the schema, processes the action,
- * and raises events for successful deletions.
+ * and raises events for successful actions.
  *
  * @param {Change[]} changesToProcess - Array of changes to process
  * @param {object} db - MongoDB database connection
@@ -43,7 +45,7 @@ export const processChanges = async (changesToProcess, db, logger) => {
         case TYPE_OF_CHANGE.DELETION:
           return processDeletion(change, db)
         case TYPE_OF_CHANGE.FIELD_CHANGE:
-          return { success: true }
+          return processDataChange(change, db)
         default:
           // This shouldn't ever happen as the scheme gets validated
           return { success: false, ...change, reason: 'Unknown action' }
@@ -92,3 +94,154 @@ const processDeletion = async (change, db) => {
     return { success: false, ...change, reason: error.message }
   }
 }
+
+const processDataChange = async (change, db) => {
+  const raisedBy = 'Admin2'
+  try {
+    const result = await updateClaimData({
+      db,
+      reference: change.claimRef,
+
+      updatedProperty: change.field,
+      newValue: change.newValue,
+      oldValue: change.oldValue,
+      note: change.note,
+      user: raisedBy,
+      updatedAt: new Date()
+    })
+
+    if (result === null) {
+      return { success: false, ...change, reason: 'Does not exists' }
+    }
+
+    await claimDataUpdateEvent(
+      {
+        applicationReference: change.applicationRef,
+        reference: change.claimRef,
+        newValue: change.newValue,
+        oldValue: change.oldValue,
+        updatedProperty: 'dateOfTesting',
+        note: change.note
+      },
+      'claim-testResults',
+      raisedBy,
+      new Date(),
+      change.sbi
+    )
+
+    return { success: true, ...change }
+  } catch (error) {
+    return { success: false, ...change, reason: 'Connection failed' }
+  }
+}
+
+// Examples of data changes to be implemented
+// -  //Data Change 1
+// -  const update1 = datastoreUpdates[0]
+// -  const claim = await getClaimByReference(db, update1.claimRef)
+// -  const herd = await getHerdById(db, claim.herd.id)
+// -
+// -  //We update the current version of the herd to indicate it is
+// -  //no longer the current one
+// -  await updateIsCurrentHerd(db, herd.id, false, herd.version)
+// -
+// -  delete herd._id
+// -  delete herd.createdAt
+// -  delete herd.updatedAt
+// -  delete herd.updatedBy
+// -  delete herd.migratedRecord
+// -  herd.createdBy = raisedBy
+// -  herd.updatedAt = {}
+// -  herd.version = herd.version + 1
+// -  herd.reasons = update1.newReason
+// -  //We are creating a new version with the new reason
+// -  await createHerd(db, herd)
+// -
+// -  const claimHerdData = claim.herd
+// -  claimHerdData.version = herd.version
+// -  claimHerdData.reasons = herd.reasons
+// -  claimHerdData.associatedAt = new Date()
+// -
+// -  await updateHerd({
+// -    db,
+// -    claimRef: update1.claimRef,
+// -    updatedProperty: 'herdReasons',
+// -    newValue: update1.newReason,
+// -    oldValue: update1.oldReason,
+// -    note,
+// -    createdBy: raisedBy,
+// -    claimHerdData
+// -  })
+// -
+// -  //Data Change 2
+// -  const update2 = datastoreUpdates[1]
+// -  await updateClaimData({
+// -    db,
+// -    reference: update2.claimRef,
+// -    updatedProperty: 'dateOfTesting',
+// -    newValue: update2.newValue,
+// -    oldValue: update2.oldValue,
+// -    note,
+// -    user: raisedBy,
+// -    updatedAt: new Date()
+// -  })
+// -  const herdAssociatedEvent = 'claim-herdAssociated'
+// -  const herdAssociatedMessage = 'Herd associated with claim updated'
+// -
+// -  //Data Change 1
+// -  const event1 = events[0]
+// -
+// -  const raisedOn = new Date()
+// -  const raisedOn1 = new Date(raisedOn.getTime() + 1).toISOString()
+// -  const raisedOn2 = new Date(raisedOn.getTime() + 2).toISOString()
+// -
+// -  const claim = await getClaimByReference(db, event1.claimRef)
+// -  const herd = await getHerdById(db, claim.herd.id)
+// -
+// -  await raiseHerdEvent({
+// -    sbi: event1.sbi,
+// -    message: 'New herd version created',
+// -    type: 'herd-versionCreated',
+// -    raisedBy,
+// -    raisedOn: raisedOn1,
+// -    data: {
+// -      herdId: herd.id,
+// -      herdVersion: herd.version,
+// -      herdName: herd.name,
+// -      herdSpecies: herd.species,
+// -      herdCph: herd.cph,
+// -      herdReasonManagementNeeds: false,
+// -      herdReasonUniqueHealth: false,
+// -      herdReasonDifferentBreed: false,
+// -      herdReasonOtherPurpose: false,
+// -      herdReasonKeptSeparate: false,
+// -      herdReasonOnlyHerd: true,
+// -      herdReasonOther: false
+// -    }
+// -  })
+// -
+// -  await raiseHerdEvent({
+// -    sbi: event1.sbi,
+// -    message: herdAssociatedMessage,
+// -    type: herdAssociatedEvent,
+// -    raisedBy,
+// -    raisedOn: raisedOn2,
+// -    data: {
+// -      herdId: herd.id,
+// -      herdVersion: herd.version,
+// -      reference: event1.claimRef,
+// -      applicationReference: event1.applicationRef
+// -    }
+// -  })
+// -
+// -  //Data Change 2
+// -  const event2 = events[1]
+// -  const eventData2 = {
+// -    applicationReference: event2.applicationRef,
+// -    reference: event2.claimRef,
+// -    newValue: event2.newValue,
+// -    oldValue: event2.oldValue,
+// -    updatedProperty: 'dateOfTesting',
+// -    note
+// -  }
+// -  await claimDataUpdateEvent(eventData2, 'claim-testResults', raisedBy, new Date(), event2.sbi)

--- a/src/distributed-jobs/data-changes/process_changes.test.js
+++ b/src/distributed-jobs/data-changes/process_changes.test.js
@@ -9,7 +9,9 @@ const deletion = {
   claimRef: 'RESH-806C-B87D',
   sbi: '123456789',
   applicationRef: 'IAHW-G7B4-UTZ5',
-  action: TYPE_OF_CHANGE.DELETION
+  action: TYPE_OF_CHANGE.DELETION,
+  dateRequested: '2025-12-12T00:00:00.000Z',
+  requester: 'Some_One'
 }
 
 // const herdChange = {
@@ -27,7 +29,8 @@ const changeOfDataField = {
   sbi: '107695939',
   applicationRef: 'IAHW-21C5-1417',
   field: 'dateOfTesting',
-  note: 'This is some test',
+  dateRequested: '2025-12-12T00:00:00.000Z',
+  requester: 'Some_One',
   newValue: '2025-12-12T00:00:00.000Z',
   oldValue: '2025-12-11T00:00:00.000Z',
   action: TYPE_OF_CHANGE.FIELD_CHANGE
@@ -210,7 +213,7 @@ describe('Field change', () => {
             updatedProperty: changeOfDataField.field,
             newValue: changeOfDataField.newValue,
             oldValue: changeOfDataField.oldValue,
-            note: changeOfDataField.note,
+            note: `Requested on ${changeOfDataField.dateRequested} by ${changeOfDataField.requester}`,
             eventType: 'claim-dateOfTesting',
             createdAt: expect.any(Date),
             createdBy: 'Admin2'
@@ -243,7 +246,7 @@ describe('Field change', () => {
         newValue: changeOfDataField.newValue,
         oldValue: changeOfDataField.oldValue,
         updatedProperty: 'dateOfTesting',
-        note: changeOfDataField.note
+        note: `Requested on ${changeOfDataField.dateRequested} by ${changeOfDataField.requester}`
       },
       raisedBy: 'Admin2',
       raisedOn: expect.any(String)

--- a/src/distributed-jobs/data-changes/process_changes.test.js
+++ b/src/distributed-jobs/data-changes/process_changes.test.js
@@ -238,7 +238,7 @@ describe('Field change', () => {
       cph: 'n/a',
       checkpoint: expect.any(String),
       status: 'success',
-      type: 'claim-testResults',
+      type: 'claim-dateOfTesting',
       message: 'Claim data updated',
       data: {
         applicationReference: changeOfDataField.applicationRef,

--- a/src/distributed-jobs/data-changes/process_changes.test.js
+++ b/src/distributed-jobs/data-changes/process_changes.test.js
@@ -22,15 +22,16 @@ const deletion = {
 //   action: TYPE_OF_CHANGE.FIELD_CHANGE
 // }
 
-// const changeOfDataField = {
-//   claimRef: 'RESH-VASQ-XIXS',
-//   sbi: '107695939',
-//   applicationRef: 'IAHW-21C5-1417',
-//   field: 'dateOfTesting',
-//   newValue: '2025-12-12T00:00:00.000Z',
-//   oldValue: '2025-12-11T00:00:00.000Z',
-//   action: TYPE_OF_CHANGE.FIELD_CHANGE
-// }
+const changeOfDataField = {
+  claimRef: 'RESH-VASQ-XIXS',
+  sbi: '107695939',
+  applicationRef: 'IAHW-21C5-1417',
+  field: 'dateOfTesting',
+  note: 'This is some test',
+  newValue: '2025-12-12T00:00:00.000Z',
+  oldValue: '2025-12-11T00:00:00.000Z',
+  action: TYPE_OF_CHANGE.FIELD_CHANGE
+}
 
 // const skipDataChange = {
 //   claimRef: 'RESH-VASQ-XIXS',
@@ -65,7 +66,8 @@ beforeEach(() => {
 })
 
 const mockDeleteOne = jest.fn()
-const mockCollection = { deleteOne: mockDeleteOne }
+const mockFindOneAndUpdate = jest.fn()
+const mockCollection = { deleteOne: mockDeleteOne, findOneAndUpdate: mockFindOneAndUpdate }
 const mockDb = { collection: jest.fn(() => mockCollection) }
 const mockLogger = { info: jest.fn() }
 
@@ -186,4 +188,101 @@ describe('data structure validation', () => {
       'undefined has failed because Incorrect data structure'
     )
   })
+})
+
+describe('Field change', () => {
+  test('We can change a data field', async () => {
+    mockFindOneAndUpdate.mockResolvedValue({ reference: changeOfDataField.claimRef })
+    const results = await processChanges([changeOfDataField], mockDb, mockLogger)
+
+    expect(results[0]).toEqual({ ...changeOfDataField, success: true })
+    expect(mockFindOneAndUpdate).toHaveBeenCalledWith(
+      { reference: changeOfDataField.claimRef },
+      {
+        $set: {
+          [`data.${changeOfDataField.field}`]: changeOfDataField.newValue,
+          updatedAt: expect.any(Date),
+          updatedBy: 'Admin2'
+        },
+        $push: {
+          updateHistory: {
+            id: expect.any(String),
+            updatedProperty: changeOfDataField.field,
+            newValue: changeOfDataField.newValue,
+            oldValue: changeOfDataField.oldValue,
+            note: changeOfDataField.note,
+            eventType: 'claim-dateOfTesting',
+            createdAt: expect.any(Date),
+            createdBy: 'Admin2'
+          }
+        }
+      }
+    )
+    expect(mockDb.collection).toHaveBeenCalledWith(CLAIMS_COLLECTION)
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      `${changeOfDataField.claimRef} has processed successfully`
+    )
+  })
+
+  test('When we change a data field, an event is being sent', async () => {
+    mockFindOneAndUpdate.mockResolvedValue({ reference: changeOfDataField.claimRef })
+    await processChanges([changeOfDataField], mockDb, mockLogger)
+
+    expect(mockPublishEvent).toHaveBeenCalledWith({
+      name: 'send-session-event',
+      id: expect.any(String),
+      sbi: changeOfDataField.sbi,
+      cph: 'n/a',
+      checkpoint: expect.any(String),
+      status: 'success',
+      type: 'claim-testResults',
+      message: 'Claim data updated',
+      data: {
+        applicationReference: changeOfDataField.applicationRef,
+        reference: changeOfDataField.claimRef,
+        newValue: changeOfDataField.newValue,
+        oldValue: changeOfDataField.oldValue,
+        updatedProperty: 'dateOfTesting',
+        note: changeOfDataField.note
+      },
+      raisedBy: 'Admin2',
+      raisedOn: expect.any(String)
+    })
+  })
+
+  test('If not updated, we return no success', async () => {
+    mockFindOneAndUpdate.mockResolvedValue(null)
+    const results = await processChanges([changeOfDataField], mockDb, mockLogger)
+
+    expect(results[0]).toEqual({ ...changeOfDataField, success: false, reason: 'Does not exists' })
+    expect(mockFindOneAndUpdate).toHaveBeenCalledWith(
+      { reference: changeOfDataField.claimRef },
+      expect.any(Object)
+    )
+    expect(mockDb.collection).toHaveBeenCalledWith(CLAIMS_COLLECTION)
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      `${changeOfDataField.claimRef} has failed because Does not exists`
+    )
+  })
+
+  test('If an error is thrown, we return no success', async () => {
+    mockFindOneAndUpdate.mockRejectedValue(new Error('Connection failed'))
+    const results = await processChanges([changeOfDataField], mockDb, mockLogger)
+
+    expect(results[0]).toEqual({
+      ...changeOfDataField,
+      success: false,
+      reason: 'Connection failed'
+    })
+    expect(mockFindOneAndUpdate).toHaveBeenCalledWith(
+      { reference: changeOfDataField.claimRef },
+      expect.any(Object)
+    )
+    expect(mockDb.collection).toHaveBeenCalledWith(CLAIMS_COLLECTION)
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      `${changeOfDataField.claimRef} has failed because Connection failed`
+    )
+  })
+
+  // Herd changes will need to be implemented
 })

--- a/src/distributed-jobs/data-changes/schema.js
+++ b/src/distributed-jobs/data-changes/schema.js
@@ -12,6 +12,7 @@ export const changeSchema = Joi.object({
   applicationRef: Joi.string().required(),
   action: Joi.string().valid(TYPE_OF_CHANGE.DELETION, TYPE_OF_CHANGE.FIELD_CHANGE).required(),
   field: Joi.string().when('action', { is: TYPE_OF_CHANGE.FIELD_CHANGE, then: Joi.required() }),
+  note: Joi.string().when('action', { is: TYPE_OF_CHANGE.FIELD_CHANGE, then: Joi.required() }),
   newValue: Joi.alternatives()
     .try(Joi.string(), Joi.array())
     .when('action', { is: TYPE_OF_CHANGE.FIELD_CHANGE, then: Joi.required() }),

--- a/src/distributed-jobs/data-changes/schema.js
+++ b/src/distributed-jobs/data-changes/schema.js
@@ -12,7 +12,8 @@ export const changeSchema = Joi.object({
   applicationRef: Joi.string().required(),
   action: Joi.string().valid(TYPE_OF_CHANGE.DELETION, TYPE_OF_CHANGE.FIELD_CHANGE).required(),
   field: Joi.string().when('action', { is: TYPE_OF_CHANGE.FIELD_CHANGE, then: Joi.required() }),
-  note: Joi.string().when('action', { is: TYPE_OF_CHANGE.FIELD_CHANGE, then: Joi.required() }),
+  dateRequested: Joi.date().iso().required(),
+  requester: Joi.string().required(),
   newValue: Joi.alternatives()
     .try(Joi.string(), Joi.array())
     .when('action', { is: TYPE_OF_CHANGE.FIELD_CHANGE, then: Joi.required() }),

--- a/src/distributed-jobs/distributed-startup-job.js
+++ b/src/distributed-jobs/distributed-startup-job.js
@@ -64,7 +64,7 @@ const hasStartupJobAlreadyRun = async (serviceVersion, environmentsJobWillRun, d
 }
 
 const performDataChanges = async (serviceVersion, supportingData, db, logger) => {
-  if (serviceVersion === '0.82.6') {
+  if (serviceVersion === '0.82.7') {
     await processChanges(supportingData, db, logger)
   } else {
     logger.info(`No data changes found for service version ${serviceVersion}`)

--- a/src/distributed-jobs/distributed-startup-job.js
+++ b/src/distributed-jobs/distributed-startup-job.js
@@ -25,7 +25,7 @@ export const runDistributedStartupJob = async (db, logger) => {
     return
   }
 
-  const supportingData = config.get(supportingDataConfigKey).data
+  const supportingData = config.get(supportingDataConfigKey)?.data ?? {}
   if (Object.keys(supportingData).length === 0) {
     throw new Error(`Missing supporting data for service version ${serviceVersion}`)
   }

--- a/src/distributed-jobs/distributed-startup-job.test.js
+++ b/src/distributed-jobs/distributed-startup-job.test.js
@@ -88,6 +88,22 @@ describe('Test runDistributedStartupJob', () => {
     expect(mockCollection.insertOne).toHaveBeenCalled()
   })
 
+  it('should throw when supporting data config returns null', async () => {
+    config.getProperties.mockReturnValue({ distributedJobs: { v0827SupportingData: {} } })
+    config.get.mockImplementation((key) => {
+      const values = {
+        cdpEnvironment: 'local',
+        serviceVersion: '0.82.7',
+        'distributedJobs.v0827SupportingData': null
+      }
+      return values[key]
+    })
+
+    await expect(runDistributedStartupJob(mockDB, mockLogger)).rejects.toThrow(
+      'Missing supporting data for service version 0.82.7'
+    )
+  })
+
   it('should run job if config present but no data changes for service version', async () => {
     config.getProperties.mockReturnValue({ distributedJobs: { v000SupportingData: {} } })
     config.get.mockImplementation((key) => {

--- a/src/distributed-jobs/distributed-startup-job.test.js
+++ b/src/distributed-jobs/distributed-startup-job.test.js
@@ -36,28 +36,28 @@ describe('Test runDistributedStartupJob', () => {
   })
 
   it('should not run job when supporting data is default/empty', async () => {
-    config.getProperties.mockReturnValue({ distributedJobs: { v0826SupportingData: {} } })
+    config.getProperties.mockReturnValue({ distributedJobs: { v0827SupportingData: {} } })
     config.get.mockImplementation((key) => {
       const values = {
         cdpEnvironment: 'local',
-        serviceVersion: '0.82.6',
-        'distributedJobs.v0826SupportingData': { data: [] }
+        serviceVersion: '0.82.7',
+        'distributedJobs.v0827SupportingData': { data: [] }
       }
       return values[key]
     })
 
     await expect(runDistributedStartupJob(mockDB, mockLogger)).rejects.toThrow(
-      'Missing supporting data for service version 0.82.6'
+      'Missing supporting data for service version 0.82.7'
     )
   })
 
   it('should not run job when already been run', async () => {
-    config.getProperties.mockReturnValue({ distributedJobs: { v0826SupportingData: {} } })
+    config.getProperties.mockReturnValue({ distributedJobs: { v0827SupportingData: {} } })
     config.get.mockImplementation((key) => {
       const values = {
         cdpEnvironment: 'local',
-        serviceVersion: '0.82.6',
-        'distributedJobs.v0826SupportingData': {
+        serviceVersion: '0.82.7',
+        'distributedJobs.v0827SupportingData': {
           data: [{ claimRef: 'test', sbi: '123', applicationRef: 'app', action: 'deletion' }]
         }
       }
@@ -77,7 +77,7 @@ describe('Test runDistributedStartupJob', () => {
     config.get.mockImplementation((key) => {
       const values = {
         cdpEnvironment: 'local',
-        serviceVersion: '0.82.6'
+        serviceVersion: '0.82.7'
       }
       return values[key]
     })
@@ -108,7 +108,7 @@ describe('Test runDistributedStartupJob', () => {
   })
 
   it('should run job and executes data changes', async () => {
-    const serviceVersion = '0.82.6'
+    const serviceVersion = '0.82.7'
     const supportingDataVersion = `v${serviceVersion.replaceAll('.', '')}SupportingData`
     const supportingDataConfigKey = `distributedJobs.${supportingDataVersion}`
 


### PR DESCRIPTION
More data changes, and generalization of those changes. This now affects basic data (not herd) for a claim.

Because of limitations of the secrets, dateRequested and requester are separate, instead of being a single field with note. This would be changed in the future once we have backoffice support.