### PR TITLE
feat(claims): (AHWR-1879) set claims against flagged agreements to in check

### DIFF
--- a/src/lib/requires-compliance-check.js
+++ b/src/lib/requires-compliance-check.js
@@ -2,7 +2,13 @@ import { config } from '../config/config.js'
 import { getAndIncrementComplianceCheckCount } from '../repositories/compliance-check-count.js'
 import { STATUS } from 'ffc-ahwr-common-library'
 
-export const generateClaimStatus = async (visitDateAsString, logger, db) => {
+const isAgreementFlagged = (flags) => Array.isArray(flags) && flags.length > 0
+
+export const generateClaimStatus = async (visitDateAsString, logger, db, flags) => {
+  if (isAgreementFlagged(flags)) {
+    return STATUS.IN_CHECK
+  }
+
   if (isFeatureAssuranceEnabledAndStartedBeforeVisitDate(visitDateAsString)) {
     // feature assurance left here as option but specific implementation has been removed
     // if we want to bring it back, then call logic here

--- a/src/lib/requires-compliance-check.test.js
+++ b/src/lib/requires-compliance-check.test.js
@@ -127,4 +127,36 @@ describe('generateClaimStatus', () => {
 
     expect(result).toBe('ON_HOLD')
   })
+
+  describe('when the agreement is flagged', () => {
+    const activeFlags = [{}]
+
+    test('returns inCheck regardless of the compliance-check ratio', async () => {
+      mockConfig({ complianceCheckRatio: 5 })
+
+      const result = await generateClaimStatus('2025-06-01', mockLogger, mockDb, activeFlags)
+
+      expect(result).toBe('IN_CHECK')
+    })
+
+    test('does not consume a compliance-check slot', async () => {
+      mockConfig({ complianceCheckRatio: 5 })
+
+      await generateClaimStatus('2025-06-01', mockLogger, mockDb, activeFlags)
+
+      expect(getAndIncrementComplianceCheckCount).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('when the agreement is not flagged', () => {
+    test('applies the ratio logic for an empty flags array', async () => {
+      mockConfig({ complianceCheckRatio: 5 })
+      getAndIncrementComplianceCheckCount.mockResolvedValue(5)
+
+      const result = await generateClaimStatus('2025-06-01', mockLogger, mockDb, [])
+
+      expect(result).toBe('IN_CHECK')
+      expect(getAndIncrementComplianceCheckCount).toHaveBeenCalledTimes(1)
+    })
+  })
 })

--- a/src/processing/claim/ahwr/processor.js
+++ b/src/processing/claim/ahwr/processor.js
@@ -18,6 +18,7 @@ const addClaimAndHerdToDatabase = async ({
   claimPayload,
   logger,
   isMultiHerdsClaim,
+  flags,
   db
 }) => {
   let herdGotUpdated
@@ -46,7 +47,7 @@ const addClaimAndHerdToDatabase = async ({
         herdGotUpdated = herdResult.updated
       }
 
-      const status = await generateClaimStatus(dateOfVisit, logger, db)
+      const status = await generateClaimStatus(dateOfVisit, logger, db, flags)
 
       const createdAt = new Date()
       claim = {
@@ -110,6 +111,7 @@ export async function saveClaimAndRelatedData({
     claimPayload,
     logger,
     isMultiHerdsClaim,
+    flags,
     db
   })
 

--- a/src/processing/claim/ahwr/processor.test.js
+++ b/src/processing/claim/ahwr/processor.test.js
@@ -148,7 +148,7 @@ describe('saveClaimAndRelatedData', () => {
       },
       '123456789'
     )
-    expect(generateClaimStatus).toHaveBeenCalledWith('2025-01-01T00:00:00Z', logger, mockDb)
+    expect(generateClaimStatus).toHaveBeenCalledWith('2025-01-01T00:00:00Z', logger, mockDb, [])
   })
 
   it('should save claim without herd', async () => {
@@ -183,6 +183,35 @@ describe('saveClaimAndRelatedData', () => {
     expect(result.isMultiHerdsClaim).toBe(false)
     expect(result.claim.status).toBe('APPROVED')
     expect(mockSession.endSession).toHaveBeenCalled()
+  })
+
+  it('threads agreement flags through to generateClaimStatus', async () => {
+    const flags = [{}]
+    const claimPayload = {
+      applicationReference: 'IAHW-8ZPZ-8CLI',
+      data: {
+        typeOfLivestock: 'beef',
+        dateOfVisit: '2025-01-01T00:00:00Z'
+      },
+      createdBy: 'admin',
+      type: 'REVIEW'
+    }
+
+    getAmount.mockResolvedValue(300)
+    isMultipleHerdsUserJourney.mockReturnValue(false)
+    generateClaimStatus.mockResolvedValue('IN_CHECK')
+    createClaim.mockResolvedValue({ insertedId: '6916f837292fe87d2bac0d5c' })
+
+    await saveClaimAndRelatedData({
+      db: mockDb,
+      sbi: '123456789',
+      claimPayload,
+      claimReference: 'REBC-O9UD-0025',
+      flags,
+      logger
+    })
+
+    expect(generateClaimStatus).toHaveBeenCalledWith('2025-01-01T00:00:00Z', logger, mockDb, flags)
   })
 })
 

--- a/src/processing/claim/poultry/processor.js
+++ b/src/processing/claim/poultry/processor.js
@@ -15,6 +15,7 @@ const addClaimAndSiteToDatabase = async ({
   dateOfVisit,
   claimPayload,
   logger,
+  flags,
   db
 }) => {
   let siteCreated
@@ -39,7 +40,7 @@ const addClaimAndSiteToDatabase = async ({
       siteData = siteResult.siteData
       siteCreated = siteResult.created
 
-      const status = await generateClaimStatus(dateOfVisit, logger, db)
+      const status = await generateClaimStatus(dateOfVisit, logger, db, flags)
 
       const createdAt = new Date()
       claim = {
@@ -80,6 +81,7 @@ export async function savePoultryClaimAndRelatedData({
   sbi,
   claimPayload,
   claimReference,
+  flags,
   logger
 }) {
   const { dateOfVisit } = claimPayload.data
@@ -95,6 +97,7 @@ export async function savePoultryClaimAndRelatedData({
     dateOfVisit,
     claimPayload,
     logger,
+    flags,
     db
   })
 

--- a/src/processing/claim/poultry/processor.test.js
+++ b/src/processing/claim/poultry/processor.test.js
@@ -83,6 +83,7 @@ describe('savePoultryClaimAndRelatedData', () => {
       sbi: '123456789',
       claimPayload,
       claimReference: 'PORE-O9UD-0025',
+      flags: [],
       logger
     })
 
@@ -158,7 +159,56 @@ describe('savePoultryClaimAndRelatedData', () => {
       },
       '123456789'
     )
-    expect(generateClaimStatus).toHaveBeenCalledWith('2025-01-01T00:00:00Z', logger, mockDb)
+    expect(generateClaimStatus).toHaveBeenCalledWith('2025-01-01T00:00:00Z', logger, mockDb, [])
+  })
+
+  it('threads agreement flags through to generateClaimStatus', async () => {
+    const flags = [{}]
+    const claimPayload = {
+      applicationReference: 'POUL-8ZPZ-8CLI',
+      data: {
+        typesOfPoultry: ['broilers'],
+        dateOfVisit: '2025-01-01T00:00:00Z',
+        site: {
+          cph: '81/445/6789',
+          id: '01d6b3f1-3fa2-465e-8dc7-cc28393ba902',
+          name: 'Broilers Unit',
+          version: 1
+        }
+      },
+      createdBy: 'admin',
+      type: 'REVIEW'
+    }
+
+    processSite.mockResolvedValue({
+      claimSiteData: {
+        id: '01d6b3f1-3fa2-465e-8dc7-cc28393ba902',
+        name: 'Broilers Unit',
+        version: 1,
+        cph: '81/445/6789'
+      },
+      siteData: {
+        id: '01d6b3f1-3fa2-465e-8dc7-cc28393ba902',
+        version: 1,
+        species: 'poultry',
+        name: 'Broilers Unit',
+        cph: '81/445/6789'
+      },
+      created: true
+    })
+    generateClaimStatus.mockResolvedValue('IN_CHECK')
+    createClaim.mockResolvedValue({ insertedId: '6916f837292fe87d2bac0d5c' })
+
+    await savePoultryClaimAndRelatedData({
+      db: mockDb,
+      sbi: '123456789',
+      claimPayload,
+      claimReference: 'PORE-O9UD-0025',
+      flags,
+      logger
+    })
+
+    expect(generateClaimStatus).toHaveBeenCalledWith('2025-01-01T00:00:00Z', logger, mockDb, flags)
   })
 
   it('uses fixed poultry price for amount', async () => {

--- a/src/routes/api/claims/claims-service.js
+++ b/src/routes/api/claims/claims-service.js
@@ -92,6 +92,7 @@ const processPoultryClaim = async ({
   application,
   applicationReference,
   payload,
+  flags,
   data,
   logger,
   tempClaimReference,
@@ -121,6 +122,7 @@ const processPoultryClaim = async ({
     sbi,
     claimPayload: validatedPayload,
     claimReference,
+    flags,
     logger
   })
 
@@ -157,6 +159,7 @@ export const processClaim = async ({ payload, logger, db }) => {
       application,
       applicationReference,
       payload,
+      flags,
       data,
       logger,
       tempClaimReference,

--- a/src/routes/api/claims/claims-service.test.js
+++ b/src/routes/api/claims/claims-service.test.js
@@ -131,6 +131,7 @@ describe('processClaim', () => {
         sbi: '123456789',
         claimPayload: payload,
         claimReference: 'PORE-O9UD-0025',
+        flags: [],
         logger: mockLogger
       })
       expect(generatePoultryEventsAndComms).toHaveBeenCalledWith(
@@ -139,6 +140,26 @@ describe('processClaim', () => {
         herdData,
         'db32152a-724a-4c5d-8073-0901c8d307f7',
         true
+      )
+    })
+
+    test('passes agreement flags to savePoultryClaimAndRelatedData', async () => {
+      const flags = [{}]
+      const application = {
+        flags,
+        organisation: { sbi: '123456789' }
+      }
+      getApplication.mockResolvedValue(application)
+      savePoultryClaimAndRelatedData.mockResolvedValue({
+        claim: { reference: 'PORE-O9UD-0025' },
+        siteCreated: true,
+        herdData: {}
+      })
+
+      await processClaim({ payload, logger: mockLogger, db: mockDb })
+
+      expect(savePoultryClaimAndRelatedData).toHaveBeenCalledWith(
+        expect.objectContaining({ flags })
       )
     })
   })
@@ -288,6 +309,25 @@ describe('processClaim', () => {
         true,
         'db32152a-724a-4c5d-8073-0901c8d307f7'
       )
+    })
+
+    test('passes agreement flags to saveClaimAndRelatedData', async () => {
+      const flags = [{}]
+      const application = {
+        flags,
+        organisation: { sbi: '123456789' }
+      }
+      getApplication.mockResolvedValue(application)
+      mockIsURNNumberUnique(true)
+      saveClaimAndRelatedData.mockResolvedValue({
+        claim: { reference: 'REBC-O9UD-0025' },
+        isMultiHerdsClaim: false,
+        herdData: {}
+      })
+
+      await processClaim({ payload, logger: mockLogger, db: mockDb })
+
+      expect(saveClaimAndRelatedData).toHaveBeenCalledWith(expect.objectContaining({ flags }))
     })
 
     test('throws NotFound error when application does not exist', async () => {


### PR DESCRIPTION
## Summary
New claims created against an agreement that carries an active flag now land with a status of `In Check`, instead of following the routine compliance-check ratio. This guarantees a human reviews them and they are not auto-paid. The behaviour covers both livestock and poultry claims and applies to new claims only.

## What Changed
- Claims created against a flagged agreement are set to `In Check` at creation time.
- The flag check takes precedence over the existing 1-in-N compliance ratio and does not consume a ratio slot, so the ratio is left intact for all other claims.
- Applies to both the livestock and poultry claim journeys.
- Unflagged agreements are unaffected and keep their existing ratio-based behaviour.
- Existing claims are never changed, including when an agreement is flagged after its claims already exist.

## Why
RPA Ops need claims against flagged agreements to always go through manual check rather than auto-payment. The agreement flagging mechanism already existed but had no bearing on claim status; this change wires it into the status decision. It is a backward-compatible change contained entirely within the application backend, safe to deploy on its own.