### PR TITLE
feat: (ahwr-2061) Adding ability to search by claim type

### DIFF
--- a/src/repositories/claim/claim-search-repository.js
+++ b/src/repositories/claim/claim-search-repository.js
@@ -1,5 +1,6 @@
 import { APPLICATION_COLLECTION, CLAIMS_COLLECTION } from '../../constants/index.js'
 import { applyAgreementTypeFilter } from '../filters/agreement-type-filter.js'
+import { applyClaimTypeFilter } from '../filters/claim-type-filter.js'
 import { applyStatusFilter } from '../filters/status-filter.js'
 import { applyDateRangeFilter } from '../filters/date-range-filter.js'
 import { applySpeciesFilter } from '../filters/species-filter.js'
@@ -85,7 +86,7 @@ const applicationLookupStages = [
 ]
 
 export const searchClaims = async (db, criteria, offset, limit, sort = getDefaultSort()) => {
-  const { search, status, agreementType, dateFrom, dateTo, species, flag } = criteria
+  const { search, status, agreementType, claimType, dateFrom, dateTo, species, flag } = criteria
 
   if (search?.type && !SEARCH_TYPES.has(search.type)) {
     return { total: 0, claims: [] }
@@ -102,6 +103,7 @@ export const searchClaims = async (db, criteria, offset, limit, sort = getDefaul
   }
 
   applyAgreementTypeFilter(query, agreementType, 'applicationReference')
+  applyClaimTypeFilter(query, claimType)
   applyDateRangeFilter(query, dateFrom, dateTo)
   applySpeciesFilter(query, species)
   applyStatusFilter(query, status)

--- a/src/repositories/claim/claim-search-repository.test.js
+++ b/src/repositories/claim/claim-search-repository.test.js
@@ -261,6 +261,27 @@ describe('claim-search-repository', () => {
       expect(matchStageOf(collectionMock)).toEqual({})
     })
 
+    it.each(['REVIEW', 'FOLLOW_UP'])('restricts type when claimType is %s', async (claimType) => {
+      const { dbMock, collectionMock } = singleResultDb()
+
+      await searchClaims(dbMock, { search: null, claimType }, 0, 30, defaultSort)
+
+      expect(matchStageOf(collectionMock)).toEqual({
+        type: claimType
+      })
+    })
+
+    it.each([undefined, 'ALL'])(
+      'does not restrict type when claimType is %s',
+      async (claimType) => {
+        const { dbMock, collectionMock } = singleResultDb()
+
+        await searchClaims(dbMock, { search: null, claimType }, 0, 30, defaultSort)
+
+        expect(matchStageOf(collectionMock)).toEqual({})
+      }
+    )
+
     it('does not restrict applicationReference when agreementType is absent', async () => {
       const { dbMock, collectionMock } = singleResultDb()
 

--- a/src/repositories/filters/claim-type-filter.js
+++ b/src/repositories/filters/claim-type-filter.js
@@ -1,0 +1,7 @@
+export const applyClaimTypeFilter = (query, claimType) => {
+  if (!claimType || claimType === 'ALL') {
+    return
+  }
+
+  query.type = claimType
+}

--- a/src/repositories/filters/claim-type-filter.test.js
+++ b/src/repositories/filters/claim-type-filter.test.js
@@ -1,0 +1,35 @@
+import { applyClaimTypeFilter } from './claim-type-filter.js'
+
+describe('applyClaimTypeFilter', () => {
+  it('does not restrict when claimType is absent', () => {
+    const query = {}
+
+    applyClaimTypeFilter(query, undefined)
+
+    expect(query).toEqual({})
+  })
+
+  it('does not restrict when claimType is ALL', () => {
+    const query = {}
+
+    applyClaimTypeFilter(query, 'ALL')
+
+    expect(query).toEqual({})
+  })
+
+  it('restricts by the given claimType', () => {
+    const query = {}
+
+    applyClaimTypeFilter(query, 'REVIEW')
+
+    expect(query).toEqual({ type: 'REVIEW' })
+  })
+
+  it('restricts by FOLLOW_UP', () => {
+    const query = {}
+
+    applyClaimTypeFilter(query, 'FOLLOW_UP')
+
+    expect(query).toEqual({ type: 'FOLLOW_UP' })
+  })
+})

--- a/src/routes/api/applications/applications-routes.js
+++ b/src/routes/api/applications/applications-routes.js
@@ -15,7 +15,7 @@ import {
 } from './applications-schema.js'
 import Boom from '@hapi/boom'
 import Joi from 'joi'
-import { searchPayloadSchema } from '../schema/search-payload.schema.js'
+import { applicationSearchPayloadSchema } from '../schema/search-payload.schema.js'
 import HttpStatus from 'http-status-codes'
 import { searchApplications } from '../../../repositories/application-repository.js'
 import { trackError } from '../../../logging/logger.js'
@@ -109,13 +109,7 @@ export const applicationRoutes = [
     options: {
       description: 'Search for applications based on search criteria',
       validate: {
-        payload: Joi.object({
-          ...searchPayloadSchema,
-          sort: Joi.object({
-            field: Joi.string().valid().optional().default('CREATEDAT'),
-            direction: Joi.string().valid().optional().allow('ASC')
-          }).optional()
-        }),
+        payload: Joi.object(applicationSearchPayloadSchema),
         failAction: async (request, _h, err) => {
           request.logger.error(err, 'Application search validation error')
           throw Boom.badRequest(err.message)

--- a/src/routes/api/claims/claims-routes.js
+++ b/src/routes/api/claims/claims-routes.js
@@ -1,8 +1,8 @@
 import joi from 'joi'
-import { searchPayloadSchema } from '../schema/search-payload.schema.js'
+import { claimSearchPayloadSchema } from '../schema/search-payload.schema.js'
 import { StatusCodes } from 'http-status-codes'
 import { searchClaims } from '../../../repositories/claim/claim-search-repository.js'
-import { POULTRY_SCHEME, AHWR_SCHEME, STATUS } from 'ffc-ahwr-common-library'
+import { POULTRY_SCHEME, AHWR_SCHEME } from 'ffc-ahwr-common-library'
 import {
   createClaimHandler,
   isURNUniqueHandler,
@@ -32,21 +32,7 @@ export const claimsHandlers = [
     options: {
       description: 'Search for claims based on search criteria',
       validate: {
-        payload: joi.object({
-          ...searchPayloadSchema,
-          sort: joi
-            .object({
-              field: joi.string().valid().optional().allow(''),
-              direction: joi.string().valid().optional().allow(''),
-              reference: joi.string().valid().optional().allow('')
-            })
-            .optional(),
-          status: joi
-            .string()
-            .valid(...Object.values(STATUS))
-            .optional(),
-          species: joi.string().valid('beef', 'dairy', 'sheep', 'pigs', 'poultry').optional()
-        }),
+        payload: joi.object(claimSearchPayloadSchema),
         failAction: async (request, h, err) => {
           request.logger.setBindings({ error: err })
           return h.response({ err }).code(StatusCodes.BAD_REQUEST).takeover()
@@ -60,6 +46,7 @@ export const claimsHandlers = [
           limit,
           sort,
           agreementType,
+          claimType,
           dateFrom,
           dateTo,
           species,
@@ -67,7 +54,7 @@ export const claimsHandlers = [
         } = request.payload
         const { total, claims } = await searchClaims(
           request.db,
-          { search, status, agreementType, dateFrom, dateTo, species, flag },
+          { search, status, agreementType, claimType, dateFrom, dateTo, species, flag },
 
           offset,
           limit,

--- a/src/routes/api/claims/claims-routes.test.js
+++ b/src/routes/api/claims/claims-routes.test.js
@@ -429,6 +429,30 @@ describe('claims-routes', () => {
       })
     })
 
+    it('passes the search criteria including claimType through to searchClaims', async () => {
+      searchClaims.mockResolvedValueOnce({ total: 0, claims: [] })
+
+      await server.inject({
+        method: 'POST',
+        url: '/api/claims/search',
+        payload: {
+          search: { text: '', type: 'reset' },
+          claimType: 'REVIEW',
+          offset: 0,
+          limit: 20,
+          sort: { field: 'createdAt', direction: 'DESC' }
+        }
+      })
+
+      expect(searchClaims).toHaveBeenCalledWith(
+        mockDb,
+        expect.objectContaining({ claimType: 'REVIEW' }),
+        0,
+        20,
+        { field: 'createdAt', direction: 'DESC' }
+      )
+    })
+
     it('passes the search criteria including flag through to searchClaims', async () => {
       searchClaims.mockResolvedValueOnce({ total: 0, claims: [] })
 
@@ -508,6 +532,17 @@ describe('claims-routes', () => {
         method: 'POST',
         url: '/api/claims/search',
         payload: { agreementType: 'alpacas' }
+      })
+
+      expect(res.statusCode).toBe(400)
+      expect(searchClaims).not.toHaveBeenCalled()
+    })
+
+    it('rejects an invalid claimType with 400 and does not call searchClaims', async () => {
+      const res = await server.inject({
+        method: 'POST',
+        url: '/api/claims/search',
+        payload: { claimType: 'VET_VISIT' }
       })
 
       expect(res.statusCode).toBe(400)

--- a/src/routes/api/schema/search-payload.schema.js
+++ b/src/routes/api/schema/search-payload.schema.js
@@ -1,8 +1,9 @@
 import Joi from 'joi'
+import { STATUS } from 'ffc-ahwr-common-library'
 
 const SEARCH_MAX_LIMIT = 20
 
-export const searchPayloadSchema = {
+const commonSearchFields = {
   offset: Joi.number().default(0),
   limit: Joi.number().greater(0).default(SEARCH_MAX_LIMIT),
   agreementType: Joi.string().valid('ALL', 'IAHW', 'PBR').optional(),
@@ -14,9 +15,31 @@ export const searchPayloadSchema = {
       then: Joi.date().min(Joi.ref('dateFrom'))
     })
     .optional(),
-  status: Joi.string().valid('AGREED', 'NOT_AGREED').optional(),
   search: Joi.object({
     text: Joi.string().valid().optional().allow(''),
     type: Joi.string().valid().optional().allow('')
+  }).optional()
+}
+
+export const applicationSearchPayloadSchema = {
+  ...commonSearchFields,
+  status: Joi.string().valid('AGREED', 'NOT_AGREED').optional(),
+  sort: Joi.object({
+    field: Joi.string().valid().optional().default('CREATEDAT'),
+    direction: Joi.string().valid().optional().allow('ASC')
+  }).optional()
+}
+
+export const claimSearchPayloadSchema = {
+  ...commonSearchFields,
+  status: Joi.string()
+    .valid(...Object.values(STATUS))
+    .optional(),
+  species: Joi.string().valid('beef', 'dairy', 'sheep', 'pigs', 'poultry').optional(),
+  claimType: Joi.string().valid('ALL', 'REVIEW', 'FOLLOW_UP').optional(),
+  sort: Joi.object({
+    field: Joi.string().valid().optional().allow(''),
+    direction: Joi.string().valid().optional().allow(''),
+    reference: Joi.string().valid().optional().allow('')
   }).optional()
 }

--- a/src/routes/api/schema/search-payload.schema.test.js
+++ b/src/routes/api/schema/search-payload.schema.test.js
@@ -1,8 +1,14 @@
 import Joi from 'joi'
-import { searchPayloadSchema } from './search-payload.schema.js'
+import {
+  applicationSearchPayloadSchema,
+  claimSearchPayloadSchema
+} from './search-payload.schema.js'
 
-describe('searchPayloadSchema', () => {
-  const schema = Joi.object(searchPayloadSchema)
+describe.each([
+  ['applicationSearchPayloadSchema', applicationSearchPayloadSchema],
+  ['claimSearchPayloadSchema', claimSearchPayloadSchema]
+])('%s', (_name, payloadSchema) => {
+  const schema = Joi.object(payloadSchema)
 
   describe('dateFrom / dateTo range', () => {
     it('accepts dateFrom earlier than dateTo', () => {
@@ -54,6 +60,24 @@ describe('searchPayloadSchema', () => {
 
     it('rejects an unknown flag value', () => {
       const { error } = schema.validate({ flag: 'MAYBE' })
+
+      expect(error).toBeDefined()
+    })
+  })
+})
+
+describe('claimSearchPayloadSchema', () => {
+  const schema = Joi.object(claimSearchPayloadSchema)
+
+  describe('claimType', () => {
+    it.each(['ALL', 'REVIEW', 'FOLLOW_UP'])('accepts %s', (claimType) => {
+      const { error } = schema.validate({ claimType })
+
+      expect(error).toBeUndefined()
+    })
+
+    it('rejects an unknown claimType value', () => {
+      const { error } = schema.validate({ claimType: 'VET_VISIT' })
 
       expect(error).toBeDefined()
     })


### PR DESCRIPTION
We have added the option to do search by claim type. There is also now two distinct searchPayloadSchemas, one for applications/agreements one for claims, with common fields.