### PR TITLE
chore(deps): (AHWR-2188) add Dependabot configuration #patch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,71 @@
+version: 2
+
+updates:
+  # Update npm packages
+  - package-ecosystem: npm
+    directory: /
+    open-pull-requests-limit: 10
+
+    # Group packages into shared PR
+    groups:
+      dev:
+        applies-to: "version-updates"
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+        patterns:
+          - "*"
+
+      prod:
+        applies-to: "version-updates"
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+        patterns:
+          - "*"
+
+      security:
+        applies-to: "security-updates"
+        patterns:
+          - "*"
+
+      other:
+        update-types:
+          - "minor"
+          - "patch"
+        patterns:
+          - "*"
+
+    # Schedule run nightly
+    schedule:
+      interval: "cron"
+      cronjob: "0 0 * * *"
+
+    cooldown:
+      default-days: 7
+
+    versioning-strategy: increase
+
+    allow:
+      # Include direct package.json updates
+      - dependency-type: direct
+
+    ignore:
+      # global-agent pinned to 3.x — v4 reworks the proxy API and breaks CDP forward-proxy setup
+      - dependency-name: global-agent
+        update-types:
+          - version-update:semver-major
+
+  # Update GitHub Actions
+  - package-ecosystem: github-actions
+    directory: /
+
+    # Schedule run nightly
+    schedule:
+      interval: "cron"
+      cronjob: "0 0 * * *"
+
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## Summary
Adds Dependabot configuration to automate dependency and GitHub Actions updates for this repository, bringing it in line with the rollout already applied across other AHWR repositories.

Config only, no runtime change, deploy-safe.

## What Changed
- Add `.github/dependabot.yml` enabling npm and github-actions ecosystem updates
- Group updates into shared PRs (prod, dev, security, other) to keep the backlog manageable
- Nightly schedule with a 7-day cooldown, matching the `.npmrc` min-release-age
- Limit open PRs to 10 and restrict to direct dependencies
- Pin `global-agent` to 3.x by ignoring major bumps, since v4 reworks the proxy API and breaks the CDP forward-proxy setup

## Why
Automates dependency maintenance and surfaces security updates promptly, reducing manual tracking. Mirrors the proven configuration from the earlier service rollout so behaviour is consistent across the estate. The `global-agent` major-version pin protects the CDP forward-proxy integration.