### PR TITLE
ci: (AHWR-2188) run SonarCloud scan on Dependabot PRs #patch

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -48,7 +48,6 @@ jobs:
           exit $?
 
       - name: SonarCloud Scan
-        if: github.actor != 'dependabot[bot]'
         uses: SonarSource/sonarqube-scan-action@v5.3.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Removes the condition that skipped the SonarCloud scan on Dependabot pull requests, so the required SonarCloud status can post on them. Without this, every Dependabot PR deadlocks: the ruleset requires the SonarCloud Code Analysis status, but the scan never ran for Dependabot, so the status never posted and the PR could never merge.

## What Changed
- Remove the `if: github.actor != 'dependabot[bot]'` guard from the SonarCloud Scan step in the pull request check workflow

## Why
The scan was originally skipped for Dependabot because Dependabot-triggered runs cannot read Actions secrets, so `SONAR_TOKEN` was absent. With the token now present in the repository's Dependabot secrets store, the scan can run for Dependabot PRs and the required status posts, unblocking automated dependency updates.