### PR TITLE
fix(mongodb): (AHWR-2188) await locker.ready to support mongo-locks 3.2.0 #patch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "hapi-pulse": "4.0.0",
         "http-status-codes": "2.3.0",
         "joi": "18.2.1",
-        "mongo-locks": "3.1.2",
+        "mongo-locks": "3.2.0",
         "mongodb": "6.21.0",
         "pino": "10.3.1"
       },
@@ -12275,9 +12275,9 @@
       }
     },
     "node_modules/mongo-locks": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/mongo-locks/-/mongo-locks-3.1.2.tgz",
-      "integrity": "sha512-kizdlS1RxMbRYxZk/YjZeX0sSa55P8/JQhQoIGE1DNuxzKK7ybt8G0H0SFQqLOg1wxjmRpxHu6E9J0AzAOsgcA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mongo-locks/-/mongo-locks-3.2.0.tgz",
+      "integrity": "sha512-6qwMoI5RHs0AlQtOESuilIzoXgpu5nMCKfGivHUAcC7sUp0aZFA20SPkFns8jKwBhUaEr4iCU0pKJxbYYULp5w==",
       "license": "ISC",
       "peerDependencies": {
         "mongodb": ">=4"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "hapi-pulse": "4.0.0",
     "http-status-codes": "2.3.0",
     "joi": "18.2.1",
-    "mongo-locks": "3.1.2",
+    "mongo-locks": "3.2.0",
     "mongodb": "6.21.0",
     "pino": "10.3.1"
   },

--- a/src/common/helpers/mongodb.js
+++ b/src/common/helpers/mongodb.js
@@ -18,6 +18,7 @@ export const mongoDb = {
       const databaseName = options.databaseName
       const db = client.db(databaseName)
       const locker = new LockManager(db.collection('mongo-locks'))
+      await locker.ready
 
       await createIndexes(db)
 

--- a/src/common/helpers/mongodb.test.js
+++ b/src/common/helpers/mongodb.test.js
@@ -6,7 +6,8 @@ import { MongoClient } from 'mongodb'
 jest.mock('mongodb', () => {
   const mockDb = {
     collection: jest.fn(() => ({
-      createIndex: jest.fn()
+      createIndex: jest.fn(),
+      createIndexes: jest.fn()
     }))
   }
   const mockClient = {


### PR DESCRIPTION
## Summary
Bumps mongo-locks to 3.2.0 and adjusts the MongoDB setup to support its new index-creation behaviour.

Version 3.2.0's LockManager builds its indexes via a batched `createIndexes` call and exposes the pending build as a promise; awaiting it during startup ensures indexes are ready before use and prevents an unhandled rejection if the client closes mid-build on shutdown.

## What Changed
- Bump mongo-locks from 3.1.2 to 3.2.0
- Await the LockManager's index build during MongoDB plugin registration
- Update the MongoDB helper test mock to provide the batched createIndexes method

## Why
mongo-locks 3.2.0 arrived via the grouped Dependabot production update and changed how the LockManager creates its indexes, breaking the existing helper and its test. Bringing this in as its own change keeps it isolated and verifiable, and mirrors the same fix already merged on the payment-proxy service.